### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
       - releases/**
       - lts/**
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: "Lint & Format"


### PR DESCRIPTION
Potential fix for [https://github.com/joshuadschoep/playwright-flows/security/code-scanning/3](https://github.com/joshuadschoep/playwright-flows/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function. Since the workflow primarily performs checks, installs dependencies, and compiles code, it likely only requires `contents: read` permission. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions for specific tasks. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
